### PR TITLE
生成される目次が、EPUB3 の仕様に対して不正だったので修正

### DIFF
--- a/template/OPS/xhtml/xhtml_nav.vm
+++ b/template/OPS/xhtml/xhtml_nav.vm
@@ -77,24 +77,27 @@ nav#landmarks { display:none; }
 #foreach(${chapter} in ${chapters})
 #if ($chapter.ChapterName)
 #set($idx=$idx+1)
+#if (!${chapter.LevelStart} && $idx > 1)
+</li>
+#end
 #if (${navNest})
 #foreach(${start} in ${chapter.LevelStart})
-		<li><ol>
+		<ol>
 #end
 #end
 #if ($chapter.ChapterId)
-			<li class="chapter" id="toc${idx}"><a href="${chapter.SectionId}.xhtml#${chapter.ChapterId}">${chapter.ChapterName}</a></li>
+			<li class="chapter" id="toc${idx}"><a href="${chapter.SectionId}.xhtml#${chapter.ChapterId}">${chapter.ChapterName}</a>
 #else
-			<li class="chapter" id="toc${idx}"><a href="${chapter.SectionId}.xhtml">${chapter.ChapterName}</a></li>
+			<li class="chapter" id="toc${idx}"><a href="${chapter.SectionId}.xhtml">${chapter.ChapterName}</a>
 #end
 #if (${navNest})
 #foreach(${end} in ${chapter.LevelEnd})
-		</ol></li>
+		</li></ol>
 #end
 #end
 #end
 #end
-		</ol>
+		</li></ol>
 	</nav>
 </body>
 </html>


### PR DESCRIPTION
階層が 2 階層より多くなるケースについては検証できていません。
とりあえず、Narou.rb で生成したデータの変換が正常に行えて、読み込み時に厳密なチェックを行っている超縦書ビューアで正常動作するのを確認しました。